### PR TITLE
Fix missing reference to CoreAnimation/CAEmitterCell.cs

### DIFF
--- a/src/Make.shared
+++ b/src/Make.shared
@@ -44,6 +44,7 @@ SHARED_SOURCE = \
 	./CoreAnimation/CALayer.cs			\
 	./CoreAnimation/CATextLayer.cs			\
 	./CoreAnimation/CAMediaTimingFunction.cs	\
+	./CoreAnimation/CAEmitterCell.cs		\
 	./CoreFoundation/CFArray.cs                     \
 	./CoreFoundation/CFBoolean.cs                   \
 	./CoreFoundation/CFDictionary.cs                \


### PR DESCRIPTION
src/Make.shared is missing a reference to the maccore CoreAnimation/CAEmitterCell.cs file
